### PR TITLE
Fix dead guides link

### DIFF
--- a/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -6,7 +6,7 @@ metadata:
     - parser
     - document
     - writer
-  guide: "https://quarkiverse.github.io/quarkiverse-docs/itext/dev/"
+  guide: "https://quarkiverse.github.io/quarkiverse-docs/quarkus-itext/dev/"
   icon-url: "https://upload.wikimedia.org/wikipedia/commons/thumb/8/87/PDF_file_icon.svg/195px-PDF_file_icon.svg.png"
   categories:
     - "miscellaneous"


### PR DESCRIPTION
https://github.com/quarkiverse/quarkus-itext/commit/7a87ebcae2583978d7b44dfee761cbd1155b4f91 changed the docs link, but the new link is not valid. (If another change is underway to change https://quarkiverse.github.io/quarkiverse-docs/quarkus-itext/dev/ to https://quarkiverse.github.io/quarkiverse-docs/itext/dev/ on the docs site, we can ignore this PR.)