### PR TITLE
Add PDFPTable.addCellAsCell for PrimeFaces

### DIFF
--- a/integration-tests/src/main/java/io/quarkiverse/itext/it/ItextResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/itext/it/ItextResource.java
@@ -26,6 +26,8 @@ import com.lowagie.text.Document;
 import com.lowagie.text.DocumentException;
 import com.lowagie.text.Paragraph;
 import com.lowagie.text.pdf.PdfName;
+import com.lowagie.text.pdf.PdfPCell;
+import com.lowagie.text.pdf.PdfPTable;
 import com.lowagie.text.pdf.PdfString;
 import com.lowagie.text.pdf.PdfWriter;
 
@@ -62,6 +64,7 @@ public class ItextResource {
             Paragraph paragraph = new Paragraph("Hello World");
             addEmptyLine(paragraph, 3);
             document.add(paragraph);
+            document.add(addTable());
         } catch (DocumentException de) {
             System.err.println(de.getMessage());
             throw new RuntimeException(de);
@@ -77,5 +80,12 @@ public class ItextResource {
         for (int i = 0; i < number; i++) {
             paragraph.addParagraph(new Paragraph(" "));
         }
+    }
+
+    protected PdfPTable addTable() {
+        PdfPTable pdfTable = new PdfPTable(5);
+        PdfPCell cell = new PdfPCell(new Paragraph(" "));
+        pdfTable.addCellAsCell(cell);
+        return pdfTable;
     }
 }

--- a/itext/src/main/java/com/lowagie/text/pdf/PdfPTable.java
+++ b/itext/src/main/java/com/lowagie/text/pdf/PdfPTable.java
@@ -446,7 +446,7 @@ public class PdfPTable implements LargeElement {
      *
      * @param cell the cell element
      */
-    public void addCell(PdfPCell cell) {
+    public void addCellAsCell(PdfPCell cell) {
         rowCompleted = false;
         PdfPCell ncell = new PdfPCell(cell);
 
@@ -502,6 +502,15 @@ public class PdfPTable implements LargeElement {
             currentRow[currentRowIdx] = ncell;
             currentRowIdx += colspan;
         }
+    }
+
+    /**
+     * Adds a cell element.
+     *
+     * @param cell the cell element
+     */
+    public void addCell(PdfPCell cell) {
+        addCellAsCell(cell);
     }
 
     /**

--- a/runtime/src/main/java/io/quarkiverse/itext/runtime/ItextFeature.java
+++ b/runtime/src/main/java/io/quarkiverse/itext/runtime/ItextFeature.java
@@ -19,10 +19,18 @@
 package io.quarkiverse.itext.runtime;
 
 import org.graalvm.nativeimage.hosted.Feature;
+import org.graalvm.nativeimage.hosted.RuntimeClassInitialization;
+
+import com.lowagie.text.pdf.PdfPublicKeySecurityHandler;
 
 public class ItextFeature implements Feature {
 
     private final static String REASON = "iText runtime initialization";
+
+    @Override
+    public void afterRegistration(AfterRegistrationAccess access) {
+        RuntimeClassInitialization.initializeAtRunTime(PdfPublicKeySecurityHandler.class.getName());
+    }
 
     @Override
     public String getDescription() {


### PR DESCRIPTION
Need this to prevent.

```
com.oracle.svm.core.util.UserError$UserException: Unsupported features in 2 methods
Detailed message:
Error: Discovered unresolved method during parsing: com.lowagie.text.pdf.PdfPTable.addCell(com.lowagie.text.pdf.PdfPCell). This error is reported at image build time because class org.primefaces.component.treetable.export.TreeTablePDFExporter is registered for linking at image build time by command line and command line.
Error encountered while parsing org.primefaces.component.treetable.export.TreeTablePDFExporter.addFacetValue(TreeTablePDFExporter.java:244)
Parsing context:
   at root method.(Unknown Source)
```